### PR TITLE
Rework how "RUCIO_ACCOUNT" env variable is set.

### DIFF
--- a/samplemanager/rucio_manager.py
+++ b/samplemanager/rucio_manager.py
@@ -20,9 +20,10 @@ class RucioManager(object):
         if "RUCIO_ACCOUNT" not in os.environ:
             dn = subprocess.check_output(["grid-proxy-info", "-identity"]).strip()
             dn = dn.decode("utf-8")
-            os.environ["RUCIO_ACCOUNT"] = os.environ.get("USER", "")
+            guess_user = os.environ.get("USER", "")
+            os.environ["RUCIO_ACCOUNT"] = guess_user
             print(
-                f"Warning! 'RUCIO_ACCOUNT' was set to {os.environ.get("USER", "")}. This might be wrong."
+                f"Warning! 'RUCIO_ACCOUNT' was set to {guess_user}. This might be wrong."
                 "Set the 'RUCIO_ACCOUNT' env variable to the correct name if it is different."
             )
 

--- a/samplemanager/rucio_manager.py
+++ b/samplemanager/rucio_manager.py
@@ -13,18 +13,19 @@ class RucioManager(object):
         self.client = Client()
         self.scope = "cms"
 
-    def setup_rucio_account(self, cert=None):
+    def setup_rucio_account(self):
         os.environ["RUCIO_CONFIG"] = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "rucio.cfg"
         )
         if "RUCIO_ACCOUNT" not in os.environ:
-            if not cert:
-                cert = os.environ["X509_USER_PROXY"]
             dn = subprocess.check_output(["grid-proxy-info", "-identity"]).strip()
             dn = dn.decode("utf-8")
-            print(f"Proxy with identity {dn} found.")
-            rucio_name = input("RUCIO_ACCOUNT env variable not set. Please provide your cern username:")
-            os.environ["RUCIO_ACCOUNT"] = rucio_name
+            os.environ["RUCIO_ACCOUNT"] = os.environ.get("USER", "")
+            print(
+                f"Warning! 'RUCIO_ACCOUNT' was set to {os.environ.get("USER", "")}. This might be wrong."
+                "Set the 'RUCIO_ACCOUNT' env variable to the correct name if it is different."
+            )
+
 
         # warn if account not found
         if "RUCIO_ACCOUNT" not in os.environ:

--- a/samplemanager/rucio_manager.py
+++ b/samplemanager/rucio_manager.py
@@ -22,13 +22,9 @@ class RucioManager(object):
                 cert = os.environ["X509_USER_PROXY"]
             dn = subprocess.check_output(["grid-proxy-info", "-identity"]).strip()
             dn = dn.decode("utf-8")
-            os.environ["RUCIO_ACCOUNT"] = os.environ.get("USER", "")
-            # url = "http://cms-cric.cern.ch/api/accounts/user/query/?json&preset=people"
-            # result = readJSON(url, params=None, cert=cert, method="GET")
-            # for person in result["result"]:
-            #     if person[4] == dn:
-            #         os.environ["RUCIO_ACCOUNT"] = person[0]
-            #         break
+            print(f"Proxy with identity {dn} found.")
+            rucio_name = input("RUCIO_ACCOUNT env variable not set. Please provide your cern username:")
+            os.environ["RUCIO_ACCOUNT"] = rucio_name
 
         # warn if account not found
         if "RUCIO_ACCOUNT" not in os.environ:


### PR DESCRIPTION
Formerly: Assume that local USER name is the same as relevant RUCIO_ACCOUNT name, if not already set.
Now: Provide prompt to user to enter relevant RUCIO_ACCOUNT name instead.