### PR TITLE
small fix in produce sample file

### DIFF
--- a/samplemanager/sample_manager.py
+++ b/samplemanager/sample_manager.py
@@ -74,6 +74,7 @@ class SampleManager(object):
                 continue
             elif task == 5:
                 self.create_production_file()
+                continue
             elif task == 6:
                 self.update_genweight()
                 continue


### PR DESCRIPTION
There was a continue missing after the create production file call. That lead to empty sample.txt files.