### PR TITLE
Fix eras in private NMSSM samples

### DIFF
--- a/nanoAOD_v15/2024/data/Tau_Run2024I-MINIv6NANOv15.json
+++ b/nanoAOD_v15/2024/data/Tau_Run2024I-MINIv6NANOv15.json
@@ -95,5 +95,5 @@
     "nfiles": 86,
     "nick": "Tau_Run2024I-MINIv6NANOv15",
     "sample_type": "data",
-    "xsec": 1.0
+    "xsec": 0.0
 }

--- a/nanoAOD_v15/2024/data/Tau_Run2024I-MINIv6NANOv15.json
+++ b/nanoAOD_v15/2024/data/Tau_Run2024I-MINIv6NANOv15.json
@@ -95,5 +95,5 @@
     "nfiles": 86,
     "nick": "Tau_Run2024I-MINIv6NANOv15",
     "sample_type": "data",
-    "xsec": 0.0
+    "xsec": 1.0
 }

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_1_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_1_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_1/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_1/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-4dfea81e/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-4dfea81e/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1200-MY-1000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1200-MY-1000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1200-MY-1000_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1200-MY-1000_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1400-MY-1200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1400-MY-1200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1400-MY-1200_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1400-MY-1200_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1600-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1600-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1600-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1600-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1800-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-1800-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1800-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-1800-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-9cbf74c8/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-9cbf74c8/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-150_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-150_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-95_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-95_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-80c850ea/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-2000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-2000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-2000_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-9cbf74c8/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-2000_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-9cbf74c8/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-300_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-654eeb7b/nanoAODv15_1.root"
     ],

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-331b8393/nanoAODv15_1.root"
     ],

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3500-MY-2600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-3500-MY-2600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3500-MY-2600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-3500-MY-2600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-150_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-150_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-200_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-200_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-60_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-60_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-60_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-60_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-70_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-70_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-70_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-70_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-80_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-80_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-80_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-80_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-90_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-90_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-90_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-90_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-95_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-95_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-300_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-300_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-300_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-300_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-600-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-600-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-600-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-600-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-400_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-144f2217/nanoAODv15_2.root"

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-500_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-500_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-3c2d438c/nanoAODv15_10.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-700-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-700-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-700-MY-500_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-700-MY-500_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-800-MY-600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
+++ b/nanoAOD_v15/2025/nmssm_Ybb/NMSSM-XtoYHto2B2Tau_Par-MX-800-MY-600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private.json
@@ -1,6 +1,6 @@
 {
     "dbs": null,
-    "era": "2024",
+    "era": "2025",
     "filelist": [
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-800-MY-600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_1.root",
         "root://cmsdcache-kit-disk.gridka.de:1094//store/user/psand/mc_production/NMSSM-XtoYHto2B2Tau_Par-MX-800-MY-600_TuneCP5_13p6TeV_madgraph-pythia8/NanoAODv15-448fc190/nanoAODv15_2.root",

--- a/nanoAOD_v15/datasets.json
+++ b/nanoAOD_v15/datasets.json
@@ -18774,7 +18774,7 @@
         "nfiles": 86,
         "nick": "Tau_Run2024I-MINIv6NANOv15",
         "sample_type": "data",
-        "xsec": 0.0
+        "xsec": 1.0
     },
     "Tau_Run2024I-MINIv6NANOv15-v1": {
         "dbs": "/Tau/Run2024I-MINIv6NANOv15-v1/NANOAOD",

--- a/nanoAOD_v15/datasets.json
+++ b/nanoAOD_v15/datasets.json
@@ -3675,7 +3675,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_1_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -3719,7 +3719,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 2000,
@@ -3939,7 +3939,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1000-MY-800_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -4049,7 +4049,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1200-MY-1000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -4423,7 +4423,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1400-MY-1200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -4797,7 +4797,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1600-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -5215,7 +5215,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-1800-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -5633,7 +5633,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-2000-MY-1800_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -5985,7 +5985,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -6051,7 +6051,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-1600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -6271,7 +6271,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-2500-MY-800_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -6381,7 +6381,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6425,7 +6425,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6469,7 +6469,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-60_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6513,7 +6513,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-70_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6557,7 +6557,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-80_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6601,7 +6601,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-90_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6645,7 +6645,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-300-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 200000,
@@ -6821,7 +6821,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-1800_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -6865,7 +6865,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-2000_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -6953,7 +6953,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 1000,
@@ -6997,7 +6997,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-3000-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 2000,
@@ -7415,7 +7415,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-3500-MY-2600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7701,7 +7701,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-100_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7745,7 +7745,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-150_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7789,7 +7789,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -7833,7 +7833,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-60_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7877,7 +7877,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-70_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7921,7 +7921,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-80_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -7965,7 +7965,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-90_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -8009,7 +8009,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-400-MY-95_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -8581,7 +8581,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-200_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2025",
+        "era": "2026",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -8625,7 +8625,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-500-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -8845,7 +8845,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-300_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -8889,7 +8889,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-550-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -9131,7 +9131,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-600-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -9373,7 +9373,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-400_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -9417,7 +9417,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-650-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 100000,
@@ -9681,7 +9681,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-700-MY-500_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,
@@ -9967,7 +9967,7 @@
     },
     "NMSSM-XtoYHto2B2Tau_Par-MX-800-MY-600_TuneCP5_13p6TeV_madgraph-pythia8_RunIII2025Summer24NanoAODv15-150X-kit-private": {
         "dbs": null,
-        "era": "2024",
+        "era": "2025",
         "generator_weight": 1.0,
         "instance": null,
         "nevents": 50000,


### PR DESCRIPTION
The database entries of the private NMSSM samples in 2025 contain the era "2024". This pull request updates the era of these samples to "2025".